### PR TITLE
Add FilterInterface & CountableFilterInterface missing methods

### DIFF
--- a/src/Contracts/CountableFilterInterface.php
+++ b/src/Contracts/CountableFilterInterface.php
@@ -6,6 +6,13 @@ use Czim\Filter\CountableResults;
 interface CountableFilterInterface extends FilterInterface
 {
     /**
+     * Returns a list of the countable parameters to get counts for
+     *
+     * @return array
+     */
+    public function getCountables();
+
+    /**
      * Gets alternative counts per (relevant) attribute for the filter data.
      *
      * @param array $countables     if provided, limits the result to theses countables
@@ -29,4 +36,11 @@ interface CountableFilterInterface extends FilterInterface
      */
     public function unignoreCountable($countable);
 
+    /**
+     * Returns whether a given countable is currently being ignored/omitted
+     *
+     * @param string $countableName
+     * @return bool
+     */
+    public function isCountableIgnored($countableName);
 }

--- a/src/Contracts/FilterInterface.php
+++ b/src/Contracts/FilterInterface.php
@@ -18,22 +18,12 @@ interface FilterInterface
     public function getFilterData();
 
     /**
-     * Applies the loaded FilterData to a query (builder)
+     * Setter for global settings
      *
-     * @param Model|EloquentBuilder $query
-     * @return EloquentBuilder
+     * @param string $key
+     * @param null   $value
      */
-    public function apply($query);
-
-    /**
-     * Adds a query join to be added after all parameters are applied
-     *
-     * @param string $key           identifying key, used to prevent duplicates
-     * @param array  $parameters
-     * @param string $joinType      'inner', 'right', defaults to left join
-     * @return $this
-     */
-    public function addJoin($key, array $parameters, $joinType = null);
+    public function setSetting($key, $value = null);
 
     /**
      * Getter for settings
@@ -51,4 +41,21 @@ interface FilterInterface
      */
     public function parameterValue($name);
 
+    /**
+     * Applies the loaded FilterData to a query (builder)
+     *
+     * @param Model|EloquentBuilder $query
+     * @return EloquentBuilder
+     */
+    public function apply($query);
+
+    /**
+     * Adds a query join to be added after all parameters are applied
+     *
+     * @param string $key           identifying key, used to prevent duplicates
+     * @param array  $parameters
+     * @param string $joinType      'inner', 'right', defaults to left join
+     * @return $this
+     */
+    public function addJoin($key, array $parameters, $joinType = null);
 }


### PR DESCRIPTION
Added all public methods from concrete implementations to contracts. Reordered methods in `FilterInterface` to fit current concrete implementation order.