### PR TITLE
Add support for Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php" : "^8.1",
-        "illuminate/support": "^10 || ^11",
-        "illuminate/database": "^10 || ^11",
+        "illuminate/support": "^10 || ^11 || ^12",
+        "illuminate/database": "^10 || ^11 || ^12",
         "myclabs/php-enum": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
This PR updates composer.json constraints so that it can be used with Laravel 12.

I've tested this update on a project that heavily relies on Laravel Filter and everything seems to work fine.